### PR TITLE
Added Deck table to dashboard ui

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { Navigate } from "react-router-dom";
 import { User } from "../models/user"
 import { DataGrid, GridColDef, GridValueGetterParams } from '@mui/x-data-grid';
 import { Cards } from "../models/cards";
+import { Decks } from "../models/decks";
 
 
 
@@ -14,16 +15,22 @@ interface IDashboardProps {
 function Dashboard(props: IDashboardProps) {
 
     const [users, setUsers] = useState([] as User[]); 
-    const [cards, setCards] = useState([] as Cards[]); 
+    const [cards, setCards] = useState([] as Cards[]);
+    const [decks, setDecks] = useState([] as Decks[]);
     //const [users, setUsers] = useState<User[]>([]); // also works
     
-    const columns: GridColDef[] = [
+    const cardColumns: GridColDef[] = [
         { field: 'id', headerName: 'ID', width: 70 },
         { field: 'html_q', headerName: 'Question', width: 300 },
-        { field: 'html_a', headerName: 'Answer', width: 300},
-        // { field: 'lname', headerName: 'Last name', width: 130 },
-        // { field: 'username', headerName: 'Username', width: 260 },
+        { field: 'html_a', headerName: 'Answer', width: 300}
       ];
+
+    const deckColumns: GridColDef[] = [
+        { field: 'deck_id', headerName: 'Deck ID', width: 70},
+        { field: 'owner_id', headerName: 'Owner ID', width: 300 },
+        { field: 'deckname', headerName: 'Deck Name', width: 300},
+        { field: 'numOfCards', headerName: 'Number of Cards', width: 300}
+    ];
 
 
 
@@ -32,14 +39,22 @@ function Dashboard(props: IDashboardProps) {
     //last lecture of Thursday on JSX and lifecycle
     useEffect(() => {
         console.log('the dashboard component was rendered');
+
         fetch('http://localhost:5000/notecard/auth/data/cards') // GET by default
             .then(resp => resp.json())  // return keyword is implicit
             .then(data => setCards(data as unknown as Cards[]));
+
+        // fetch('http://localhost:5000/notecard/auth/data/decks') // GET by default
+        //     .then(resp => resp.json())  // return keyword is implicit
+        //     .then(data => setDecks(data as unknown as Decks[]));
+
 
         return () => {
             console.log('the dashboard component was derendered');
         }
     }, []);
+
+
 
     return ( 
         !props.currentUser ? //<p>You're not logged in</p> :
@@ -51,14 +66,25 @@ function Dashboard(props: IDashboardProps) {
             <div style={{ height: 400, width: '100%' }}>
                 <DataGrid
                 rows={cards}
-                columns={columns}
+                columns={cardColumns}
                 pageSize={5}
                 rowsPerPageOptions={[5]}
                 checkboxSelection
                 />
             </div>
 
+            <br/>
 
+            <Typography variant="subtitle1">Decks</Typography>
+            <div style={{ height: 400, width: '100%' }}>
+                <DataGrid
+                rows={decks}
+                columns={deckColumns}
+                pageSize={5}
+                rowsPerPageOptions={[5]}
+                checkboxSelection
+                />
+            </div>
             {/* <table>
                 <thead>
                     <tr>

--- a/src/models/decks.ts
+++ b/src/models/decks.ts
@@ -2,16 +2,16 @@ import { Cards } from "./cards";
 
 export class Decks {
 
-    deckId: number;
-    ownerId: number;
-    deckName: string;
+    deck_id: number;
+    owner_id: number;
+    deckname: string;
     cards: Cards[];
 
 
     constructor(deckId: number, ownerId: number, deckName: string, cards: Cards[]) {
-        this.deckId = deckId;
-        this.ownerId = ownerId;
-        this.deckName = deckName;
+        this.deck_id = deckId;
+        this.owner_id = ownerId;
+        this.deckname = deckName;
         this.cards = cards;
     }
 


### PR DESCRIPTION
The Deck list doesn't load yet because the Data Grid component requires a unique id field labeled "id" to be present on all rows, but we currently have the parameters set to "owner_id" and "deck_id". 